### PR TITLE
chore: allow overriding root path with $EMBER_CLI_ROOT

### DIFF
--- a/lib/ember_cli.rb
+++ b/lib/ember_cli.rb
@@ -53,7 +53,11 @@ module EmberCli
   end
 
   def root
-    @root ||= Rails.root.join("tmp", "ember-cli").tap(&:mkpath)
+    @root ||= if ENV["EMBER_CLI_ROOT"].present?
+      Pathname.new(ENV["EMBER_CLI_ROOT"])
+    else
+      Rails.root.join("tmp", "ember-cli")
+    end.tap(&:mkpath)
   end
 
   def env


### PR DESCRIPTION
By deafult, this gem writes into `tmp/ember-cli`, which doesn't make any sense when you're building ahead-of-time and `tmp/` isn't the same between build-time and run-time